### PR TITLE
refactor: (#6) OrderLine 에러 케이스 해결

### DIFF
--- a/src/main/java/com/domaindriven/order/OrderLine.java
+++ b/src/main/java/com/domaindriven/order/OrderLine.java
@@ -1,8 +1,10 @@
 package com.domaindriven.order;
 
+import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
 
 import lombok.AllArgsConstructor;
 
@@ -10,10 +12,9 @@ import lombok.AllArgsConstructor;
 @Embeddable
 public class OrderLine {
 
-    // index 2 out of bounds for length 2 Exception. 이유가 뭘까?
-//    @Embedded
-//    @AttributeOverride(name = "productId", column = @Column(name = "product_id"))
-//    private ProductId productId;
+    @Embedded
+    @AttributeOverride(name = "productId", column = @Column(name = "product_id"))
+    private ProductId productId;
 
     @Convert(converter = MoneyConverter.class)
     @Column(name = "price")

--- a/src/main/java/com/domaindriven/order/ProductId.java
+++ b/src/main/java/com/domaindriven/order/ProductId.java
@@ -11,4 +11,12 @@ public class ProductId {
     private Long productId;
 
     protected ProductId() {}
+
+    public Long getProductId() {
+        return this.productId;
+    }
+
+    public void setProductId(long productId) {
+        this.productId = productId;
+    }
 }

--- a/src/test/java/com/domaindriven/order/OrderTest.java
+++ b/src/test/java/com/domaindriven/order/OrderTest.java
@@ -25,6 +25,7 @@ public class OrderTest {
                         new ShippingInfo("address", "zipCode"),
                         new Money(1000L),
                         Collections.singletonList(new OrderLine(
+                                new ProductId(1L),
                                 new Money(100L),
                                 3)),
                         new EmailSet(Set.of(
@@ -36,6 +37,7 @@ public class OrderTest {
                         new ShippingInfo("address2", "zipCode2"),
                         new Money(2000000L),
                         Collections.singletonList(new OrderLine(
+                                new ProductId(2L),
                                 new Money(100L),
                                 3)),
                         new EmailSet(Set.of(


### PR DESCRIPTION
* ProductId 클래스에 getter/setter 추가
  * compile 시점에 hibernate에서 attributes를 참조할 때, getter와 setter가 필요함
  * [Hibernate Refer](https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-pojo-accessors)