### PR TITLE
feat: subselect entity 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+test.sql
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/src/main/java/com/domaindriven/article/ArticleWriter.java
+++ b/src/main/java/com/domaindriven/article/ArticleWriter.java
@@ -1,0 +1,40 @@
+package com.domaindriven.article;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Subselect;
+import org.hibernate.annotations.Synchronize;
+
+import lombok.Getter;
+
+@Getter
+@Entity
+@Immutable // 하이버네이트의 테이블 업데이트를 무시하도록 한다 (View 모델을 Update하고자 할 경우 Error 발생)
+@Subselect(" " // hibernate의 문법을 그대로 따라야한다
+           + " SELECT a.article_id as article_id, "
+           + "        a.title as title, "
+           + "        w.writer_id as writer_id, "
+           + "        w.name as name "
+           + "   FROM d_article a, "
+           + "         d_writer w "
+           + "  WHERE a.article_id = w.article_id")
+@Synchronize({ "D_ARTICLE", "D_ATTRIBUTE_CONTENT", "D_WRITER" }) // Sync로 명시된 테이블에 변경 사항이 존재할 경우, 본 Entity 조회 시점 이전에 Sync 테이블의 변경사항을 먼저 반영한다
+public class ArticleWriter {
+
+    @Id
+    private long articleId;
+
+    private String title;
+
+    private long writerId;
+
+    private String name;
+
+    protected ArticleWriter() {}
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/src/main/java/com/domaindriven/article/ArticleWriterRepository.java
+++ b/src/main/java/com/domaindriven/article/ArticleWriterRepository.java
@@ -1,0 +1,8 @@
+package com.domaindriven.article;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleWriterRepository extends JpaRepository<ArticleWriter, Long> {
+
+    ArticleWriter findArticleWriterByArticleId(long articleId);
+}

--- a/src/main/java/com/domaindriven/article/Writer.java
+++ b/src/main/java/com/domaindriven/article/Writer.java
@@ -1,0 +1,28 @@
+package com.domaindriven.article;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import lombok.AllArgsConstructor;
+
+@Table(name = "D_WRITER")
+@Entity
+@AllArgsConstructor
+public class Writer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long writerId;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "article_id")
+    private long articleId;
+
+    protected Writer() {}
+}

--- a/src/main/java/com/domaindriven/article/WriterRepository.java
+++ b/src/main/java/com/domaindriven/article/WriterRepository.java
@@ -1,0 +1,5 @@
+package com.domaindriven.article;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WriterRepository extends JpaRepository<Writer, Long> {}

--- a/src/test/java/com/domaindriven/article/ArticleWriterTest.java
+++ b/src/test/java/com/domaindriven/article/ArticleWriterTest.java
@@ -1,0 +1,48 @@
+package com.domaindriven.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@TestMethodOrder(OrderAnnotation.class)
+@SpringBootTest
+public class ArticleWriterTest {
+
+    @Autowired
+    ArticleRepository articleRepository;
+
+    @Autowired
+    WriterRepository writerRepository;
+
+    @Autowired
+    ArticleWriterRepository articleWriterRepository;
+
+    @Order(1)
+    @Test
+    void create() {
+        articleRepository.save(new Article(1, "title", new ArticleContent("content", "contentType")));
+        writerRepository.save(new Writer(1, "name", 1));
+        ArticleWriter articleWriter = articleWriterRepository.findArticleWriterByArticleId(1); //articleId
+        assertThat(articleWriter.getArticleId()).isEqualTo(1);
+        assertThat(articleWriter.getWriterId()).isEqualTo(1);
+        assertThat(articleWriter.getName()).isEqualTo("name");
+        assertThat(articleWriter.getTitle()).isEqualTo("title");
+    }
+
+    @Order(2)
+    @Test
+    void update() {
+        ArticleWriter articleWriter = articleWriterRepository.findArticleWriterByArticleId(1); //articleId
+        articleWriter.setTitle("changed Title");
+        ArticleWriter changedArticleWriter = articleWriterRepository.saveAndFlush(articleWriter);
+        assertThat(changedArticleWriter.getArticleId()).isEqualTo(1);
+        assertThat(changedArticleWriter.getWriterId()).isEqualTo(1);
+        assertThat(changedArticleWriter.getName()).isEqualTo("name");
+        assertThat(changedArticleWriter.getTitle()).isEqualTo("changed Title");
+    }
+}


### PR DESCRIPTION
```
* Article과 Writer의 Join 테이블인 View 모델 테이블 ArticleWriter.java 생성
* @Subselect 어노테이션으로 직접 쿼리를 명시해 View Model을 Entity로 매핑할 수 있다.
* Immutable 어노테이션으로 View 전용 가상 Entity를 Update하는 에러 케이스를 방지한다 (Hibernate에서 자동으로 무시함)
* Synchronize 어노테이션으로 Sync가 필요한 테이블들에 대한 변경사항을 View 모델 조회 시점 이전에 반영하여 데이터 불일치 현상을 완화시킨다
 ```